### PR TITLE
v1.2.1 — CI + test backfill baseline

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@v4
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,10 +17,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest ]
-        php: [ 8.3, 8.2 ]
-        laravel: [ 11.*, 12.*, 13.*]
+        php: [ 8.4, 8.3, 8.2 ]
+        laravel: [ 10.*, 11.*, 12.*, 13.*]
         stability: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.24 || ^3.0
           - laravel: 11.*
             testbench: 9.*
             carbon: ^3.0
@@ -33,12 +36,14 @@ jobs:
         exclude:
           - php: 8.2
             laravel: 13.*
+          - php: 8.4
+            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `laravel-replicate` will be documented in this file.
 
+## Unreleased
+
+### Added
+- **Test coverage.** The package previously only asserted container/facade wiring. Added `Http::fake`-based tests for every service method (26 endpoints) plus the `Http::replicate()` macro (base URL, bearer token, JSON accept header, custom API URL). Test count: 2 → 32. `Http::preventStrayRequests()` is now enabled to keep the suite hermetic.
+
+### Changed
+- **CI matrix** now tests PHP 8.4 and actually tests Laravel 10.x (previously claimed but untested). Matrix: PHP 8.2/8.3/8.4 × Laravel 10/11/12/13, with `php 8.2 + Laravel 13` and `php 8.4 + Laravel 10` excluded.
+- Bumped GitHub Actions: `actions/checkout` v4 → v6 (run-tests, phpstan, fix-php-code-style, update-changelog), `ramsey/composer-install` v3 → v4, `dependabot/fetch-metadata` v2.4.0 → v3.0.0. Supersedes dependabot #17, #21, #22.
+
+### Fixed
+- **PHPStan was broken** by an invalid `checkMissingIterableValueType` option in `phpstan.neon.dist` (removed in PHPStan 2.x). The option was removed and the existing `Http::replicate()` macro errors were captured into a fresh baseline so static analysis runs clean.
+
+### Documentation
+- README: documented the previously-undocumented `deleteModel()` method, and added an honest "Current limitations" section (pagination/filters, `Prefer`/`Cancel-After` headers, and the 6 not-yet-implemented endpoints), replacing the misleading "Reference:" line that implied full API parity.
+
 ## v1.2.0 - Laravel 13 Support - 2026-04-09
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Replicate::getModel(string $owner, string $name)
 Replicate::getModelVersion(string $owner, string $name, string $version)
 Replicate::listModelVersions(string $owner, string $name)
 Replicate::deleteModelVersion(string $owner, string $name, string $version)
+Replicate::deleteModel(string $owner, string $name)
 Replicate::listModels()
 Replicate::createPrediction(array $data)
 Replicate::getPrediction(string $id)
@@ -57,7 +58,14 @@ Replicate::defaultSecret()
 Replicate::createDeploymentPrediction(string $owner, string $name, array $data)
 Replicate::createModelPrediction(string $owner, string $name, string $version, array $data)
 ```
-#### Reference: https://replicate.com/docs/reference/http
+#### Reference
+
+This client covers a subset of the [Replicate HTTP API](https://replicate.com/docs/reference/http) (accounts, collections, deployments, hardware, models, predictions, trainings, webhooks).
+
+> **Current limitations**
+> - The list methods do not expose pagination cursors or filters (e.g. `predictions.list` `created_after`, `models.list` `sort_by`). Callers only get the first page.
+> - The prediction create methods (`createPrediction`, `createModelPrediction`, `createDeploymentPrediction`) do not forward the `Prefer` (sync mode) or `Cancel-After` headers.
+> - The `search`, `models.update`, `models.search`, `models.examples.list`, `models.readme.get`, and `deployments.delete` endpoints are not implemented yet.
 
 ## Example
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,55 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 2
+			path: config/replicate.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Services/AuthService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 2
+			path: src/Services/CollectionService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 4
+			path: src/Services/DeploymentService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Services/HardwareService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 7
+			path: src/Services/ModelService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 6
+			path: src/Services/PredictionService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 4
+			path: src/Services/TrainingService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Services/WebhookService.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/tests/HttpReplicateMacroTest.php
+++ b/tests/HttpReplicateMacroTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+
+describe('Http::replicate macro', function () {
+    it('targets the configured base url', function () {
+        Http::fake();
+
+        Http::replicate()->get('/account');
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://api.replicate.com/v1/account');
+    });
+
+    it('sends the api token as a bearer token', function () {
+        Http::fake();
+
+        Http::replicate()->get('/account');
+
+        Http::assertSent(fn ($request) => $request->hasHeader('Authorization', 'Bearer test-token'));
+    });
+
+    it('sends the json accept header', function () {
+        Http::fake();
+
+        Http::replicate()->get('/account');
+
+        Http::assertSent(fn ($request) => $request->hasHeader('Accept', 'application/json'));
+    });
+
+    it('respects a custom api url', function () {
+        config(['replicate.api_url' => 'https://custom.replicate.test/v1']);
+        Http::fake();
+
+        Http::replicate()->get('/account');
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://custom.replicate.test/v1/account');
+    });
+});

--- a/tests/ServicesTest.php
+++ b/tests/ServicesTest.php
@@ -1,0 +1,211 @@
+<?php
+
+use HalilCosdu\Replicate\Facades\Replicate;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake();
+});
+
+describe('account', function () {
+    it('GETs /account', function () {
+        Replicate::account();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/account');
+    });
+});
+
+describe('collections', function () {
+    it('GETs a collection by slug', function () {
+        Replicate::getCollection('super-resolution');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/collections/super-resolution');
+    });
+
+    it('lists collections', function () {
+        Replicate::listCollections();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/collections');
+    });
+});
+
+describe('deployments', function () {
+    it('lists deployments', function () {
+        Replicate::listDeployments();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/deployments');
+    });
+
+    it('creates a deployment', function () {
+        Replicate::createDeployment(['name' => 'my-deployment']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/deployments'
+            && $request['name'] === 'my-deployment');
+    });
+
+    it('gets a deployment', function () {
+        Replicate::getDeployment('alice', 'my-deployment');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/deployments/alice/my-deployment');
+    });
+
+    it('updates a deployment', function () {
+        Replicate::updateDeployment('alice', 'my-deployment', ['min_instances' => 2]);
+
+        Http::assertSent(fn ($request) => $request->method() === 'PATCH'
+            && $request->url() === 'https://api.replicate.com/v1/deployments/alice/my-deployment'
+            && $request['min_instances'] === 2);
+    });
+});
+
+describe('hardware', function () {
+    it('lists hardware', function () {
+        Replicate::listHardware();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/hardware');
+    });
+});
+
+describe('models', function () {
+    it('creates a model', function () {
+        Replicate::createModel(['owner' => 'alice', 'name' => 'detector']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/models'
+            && $request['name'] === 'detector');
+    });
+
+    it('gets a model', function () {
+        Replicate::getModel('alice', 'detector');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector');
+    });
+
+    it('lists models', function () {
+        Replicate::listModels();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models');
+    });
+
+    it('deletes a model', function () {
+        Replicate::deleteModel('alice', 'detector');
+
+        Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector');
+    });
+
+    it('gets a model version', function () {
+        Replicate::getModelVersion('alice', 'detector', 'abc123');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/versions/abc123');
+    });
+
+    it('lists model versions', function () {
+        Replicate::listModelVersions('alice', 'detector');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/versions');
+    });
+
+    it('deletes a model version', function () {
+        Replicate::deleteModelVersion('alice', 'detector', 'abc123');
+
+        Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/versions/abc123');
+    });
+});
+
+describe('predictions', function () {
+    it('creates a prediction', function () {
+        Replicate::createPrediction(['version' => 'abc', 'input' => ['text' => 'hi']]);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/predictions'
+            && $request['version'] === 'abc');
+    });
+
+    it('gets a prediction', function () {
+        Replicate::getPrediction('pred-1');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/predictions/pred-1');
+    });
+
+    it('lists predictions', function () {
+        Replicate::listPredictions();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/predictions');
+    });
+
+    it('cancels a prediction', function () {
+        Replicate::cancelPrediction('pred-1');
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/predictions/pred-1/cancel');
+    });
+
+    it('creates a deployment prediction', function () {
+        Replicate::createDeploymentPrediction('alice', 'my-deployment', ['input' => ['prompt' => 'x']]);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/deployments/alice/my-deployment/predictions');
+    });
+
+    it('creates an official model prediction', function () {
+        Replicate::createModelPrediction('meta', 'llama-3', 'v1', ['input' => ['prompt' => 'x']]);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/models/meta/llama-3/predictions');
+    });
+});
+
+describe('trainings', function () {
+    it('lists trainings', function () {
+        Replicate::listTrainings();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/trainings');
+    });
+
+    it('creates a training', function () {
+        Replicate::createTraining('alice', 'detector', 'v1', ['destination' => 'alice/detector-finetune']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/versions/v1/trainings'
+            && $request['destination'] === 'alice/detector-finetune');
+    });
+
+    it('gets a training', function () {
+        Replicate::getTraining('training-1');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/trainings/training-1');
+    });
+
+    it('cancels a training', function () {
+        Replicate::cancelTraining('training-1');
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/trainings/training-1/cancel');
+    });
+});
+
+describe('webhooks', function () {
+    it('gets the default webhook secret', function () {
+        Replicate::defaultSecret();
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/webhooks/default/secret');
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace HalilCosdu\Replicate\Tests;
 
 use HalilCosdu\Replicate\ReplicateServiceProvider;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
@@ -15,6 +16,9 @@ class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'HalilCosdu\\Replicate\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        // Make any un-faked HTTP request fail loudly, so tests stay hermetic.
+        Http::preventStrayRequests();
     }
 
     protected function getPackageProviders($app)
@@ -27,10 +31,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_laravel-replicate_table.php.stub';
-        $migration->up();
-        */
+        config()->set('replicate.api_token', 'test-token');
+        config()->set('replicate.api_url', 'https://api.replicate.com/v1');
     }
 }


### PR DESCRIPTION
First of two releases (sequencing agreed with Codex). Establishes a known-good **test + CI baseline** before the API-parity features land in v1.3.0. No functional/API changes.

## Added
- **Test coverage** — the package previously only asserted container/facade wiring. Added `Http::fake`-based tests for every service method (26 endpoints) plus the `Http::replicate()` macro (base URL, bearer token, JSON accept header, custom API URL). 2 → 32 tests. `Http::preventStrayRequests()` keeps the suite hermetic.

## Changed
- **CI matrix** — PHP 8.4 added; Laravel 10.x is now actually tested (v1.2.0 CHANGELOG claimed it but CI never ran it). Matrix: PHP 8.2/8.3/8.4 × Laravel 10/11/12/13 (`php 8.2 + Laravel 13` and `php 8.4 + Laravel 10` excluded).
- Bumped actions: `checkout` v6, `ramsey/composer-install` v4, `dependabot/fetch-metadata` v3.0.0. Supersedes #17, #21, #22.

## Fixed
- **PHPStan was broken** — `phpstan.neon.dist` had an invalid `checkMissingIterableValueType` option (removed in PHPStan 2.x), so static analysis never ran clean. Removed it and regenerated the baseline for the existing `Http::replicate()` macro errors.

## Docs
- README: documented the previously-undocumented `deleteModel()`, and added an honest "Current limitations" section (pagination/filters, `Prefer`/`Cancel-After`, 6 unimplemented endpoints) replacing the misleading "Reference:" parity line.

## Verification (local)
- [x] `composer test` — 32 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `composer format` — clean

> CI will likely show as failing due to the account-level Actions billing lock (same as the other repos); the code side is green locally.