### PR TITLE
v1.3.0 — API parity with the Replicate HTTP reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `laravel-replicate` will be documented in this file.
 
+## Unreleased
+
+### Added
+- **API parity — 6 previously-missing endpoints:**
+  - `search($query, $limit = null)` — new `SearchService` (beta `GET /search`).
+  - `updateModel($owner, $name, $data)` — `PATCH /models/{owner}/{name}`.
+  - `searchModels($query)` — `QUERY /models` (non-standard HTTP method, raw `text/plain` body).
+  - `listModelExamples($owner, $name, $query = [])` — `GET /models/{owner}/{name}/examples`.
+  - `getModelReadme($owner, $name)` — `GET /models/{owner}/{name}/readme` (returns plain-text Markdown).
+  - `deleteDeployment($owner, $name)` — `DELETE /deployments/{owner}/{name}`.
+- **Prediction headers** — `createPrediction`, `createModelPrediction`, and `createDeploymentPrediction` now accept an optional `$headers` array, enabling sync mode (`Prefer: wait=n`) and auto-cancel (`Cancel-After: 5m`). Backwards compatible (defaults to no extra headers).
+- **List filters / pagination** — every list method (`listPredictions`, `listModels`, `listDeployments`, `listCollections`, `listTrainings`, `listModelExamples`) now accepts an optional `$query` array forwarded as query parameters (`cursor`, `created_after`, `sort_by`, etc.). Backwards compatible.
+
+### Tests
+- Added `Http::fake` tests for every new method, including header forwarding (`Prefer`/`Cancel-After`), query-parameter forwarding, and the `QUERY`+`text/plain` body shape. Test count: 32 → 48.
+
 ## v1.2.1 - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,28 +44,44 @@ Replicate::getModel(string $owner, string $name)
 Replicate::getModelVersion(string $owner, string $name, string $version)
 Replicate::listModelVersions(string $owner, string $name)
 Replicate::deleteModelVersion(string $owner, string $name, string $version)
+Replicate::updateModel(string $owner, string $name, array $data)
+Replicate::searchModels(string $query)
+Replicate::listModelExamples(string $owner, string $name, array $query = [])
+Replicate::getModelReadme(string $owner, string $name)
 Replicate::deleteModel(string $owner, string $name)
-Replicate::listModels()
-Replicate::createPrediction(array $data)
+Replicate::listModels(array $query = [])
+Replicate::createPrediction(array $data, array $headers = [])
 Replicate::getPrediction(string $id)
 Replicate::cancelPrediction($id)
-Replicate::listPredictions()
-Replicate::listTrainings()
+Replicate::listPredictions(array $query = [])
+Replicate::listTrainings(array $query = [])
 Replicate::createTraining(string $owner, string $name, string $version, array $data)
 Replicate::getTraining(string $id)
 Replicate::cancelTraining($id)
 Replicate::defaultSecret()
-Replicate::createDeploymentPrediction(string $owner, string $name, array $data)
-Replicate::createModelPrediction(string $owner, string $name, string $version, array $data)
+Replicate::createDeploymentPrediction(string $owner, string $name, array $data, array $headers = [])
+Replicate::createModelPrediction(string $owner, string $name, string $version, array $data, array $headers = [])
+Replicate::deleteDeployment(string $owner, string $name)
+Replicate::search(string $query, ?int $limit = null)
 ```
+
+#### Optional headers (sync mode & auto-cancel)
+
+The three prediction-create methods accept an optional `$headers` array. Use it to enable sync mode and automatic cancellation:
+
+```php
+Replicate::createPrediction(
+    ['version' => '...', 'input' => ['prompt' => 'a cat']],
+    ['Prefer' => 'wait=60', 'Cancel-After' => '5m']
+);
+```
+
+#### Pagination & filters
+
+The list methods (`listPredictions`, `listModels`, `listDeployments`, `listCollections`, `listTrainings`, `listModelExamples`) accept an optional `$query` array forwarded as query parameters — e.g. `cursor`, `created_after`, `source`, `sort_by`, `sort_direction`.
 #### Reference
 
-This client covers a subset of the [Replicate HTTP API](https://replicate.com/docs/reference/http) (accounts, collections, deployments, hardware, models, predictions, trainings, webhooks).
-
-> **Current limitations**
-> - The list methods do not expose pagination cursors or filters (e.g. `predictions.list` `created_after`, `models.list` `sort_by`). Callers only get the first page.
-> - The prediction create methods (`createPrediction`, `createModelPrediction`, `createDeploymentPrediction`) do not forward the `Prefer` (sync mode) or `Cancel-After` headers.
-> - The `search`, `models.update`, `models.search`, `models.examples.list`, `models.readme.get`, and `deployments.delete` endpoints are not implemented yet.
+This client covers the [Replicate HTTP API](https://replicate.com/docs/reference/http) — accounts, collections, deployments, hardware, models, predictions, trainings, webhooks, and search.
 
 ## Example
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 		-
 			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
 			identifier: staticMethod.notFound
-			count: 4
+			count: 5
 			path: src/Services/DeploymentService.php
 
 		-
@@ -33,7 +33,7 @@ parameters:
 		-
 			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
 			identifier: staticMethod.notFound
-			count: 7
+			count: 11
 			path: src/Services/ModelService.php
 
 		-
@@ -41,6 +41,12 @@ parameters:
 			identifier: staticMethod.notFound
 			count: 6
 			path: src/Services/PredictionService.php
+
+		-
+			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: src/Services/SearchService.php
 
 		-
 			message: '#^Call to an undefined static method Illuminate\\Support\\Facades\\Http\:\:replicate\(\)\.$#'

--- a/src/Replicate.php
+++ b/src/Replicate.php
@@ -8,6 +8,7 @@ use HalilCosdu\Replicate\Services\DeploymentService;
 use HalilCosdu\Replicate\Services\HardwareService;
 use HalilCosdu\Replicate\Services\ModelService;
 use HalilCosdu\Replicate\Services\PredictionService;
+use HalilCosdu\Replicate\Services\SearchService;
 use HalilCosdu\Replicate\Services\TrainingService;
 use HalilCosdu\Replicate\Services\WebhookService;
 
@@ -20,6 +21,7 @@ readonly class Replicate
         private HardwareService $hardwareService,
         private ModelService $modelService,
         private PredictionService $predictionService,
+        private SearchService $searchService,
         private TrainingService $trainingService,
         private WebhookService $webhookService,
     ) {
@@ -36,14 +38,14 @@ readonly class Replicate
         return $this->collectionService->get($slug);
     }
 
-    public function listCollections()
+    public function listCollections(array $query = [])
     {
-        return $this->collectionService->list();
+        return $this->collectionService->list($query);
     }
 
-    public function listDeployments()
+    public function listDeployments(array $query = [])
     {
-        return $this->deploymentService->list();
+        return $this->deploymentService->list($query);
     }
 
     public function createDeployment(array $data)
@@ -59,6 +61,11 @@ readonly class Replicate
     public function updateDeployment(string $owner, string $name, array $data)
     {
         return $this->deploymentService->update($owner, $name, $data);
+    }
+
+    public function deleteDeployment(string $owner, string $name)
+    {
+        return $this->deploymentService->delete($owner, $name);
     }
 
     public function listHardware()
@@ -96,14 +103,34 @@ readonly class Replicate
         return $this->modelService->delete($owner, $name);
     }
 
-    public function listModels()
+    public function listModels(array $query = [])
     {
-        return $this->modelService->list();
+        return $this->modelService->list($query);
     }
 
-    public function createPrediction(array $data)
+    public function updateModel(string $owner, string $name, array $data)
     {
-        return $this->predictionService->create($data);
+        return $this->modelService->update($owner, $name, $data);
+    }
+
+    public function searchModels(string $query)
+    {
+        return $this->modelService->search($query);
+    }
+
+    public function listModelExamples(string $owner, string $name, array $query = [])
+    {
+        return $this->modelService->listExamples($owner, $name, $query);
+    }
+
+    public function getModelReadme(string $owner, string $name)
+    {
+        return $this->modelService->readme($owner, $name);
+    }
+
+    public function createPrediction(array $data, array $headers = [])
+    {
+        return $this->predictionService->create($data, $headers);
     }
 
     public function getPrediction(string $id)
@@ -116,14 +143,14 @@ readonly class Replicate
         return $this->predictionService->cancel($id);
     }
 
-    public function listPredictions()
+    public function listPredictions(array $query = [])
     {
-        return $this->predictionService->list();
+        return $this->predictionService->list($query);
     }
 
-    public function listTrainings()
+    public function listTrainings(array $query = [])
     {
-        return $this->trainingService->list();
+        return $this->trainingService->list($query);
     }
 
     public function createTraining(string $owner, string $name, string $version, array $data)
@@ -146,13 +173,18 @@ readonly class Replicate
         return $this->webhookService->defaultSecret();
     }
 
-    public function createDeploymentPrediction(string $owner, string $name, array $data)
+    public function createDeploymentPrediction(string $owner, string $name, array $data, array $headers = [])
     {
-        return $this->predictionService->createDeploymentPrediction($owner, $name, $data);
+        return $this->predictionService->createDeploymentPrediction($owner, $name, $data, $headers);
     }
 
-    public function createModelPrediction(string $owner, string $name, string $version, array $data)
+    public function createModelPrediction(string $owner, string $name, string $version, array $data, array $headers = [])
     {
-        return $this->predictionService->createModelPrediction($owner, $name, $version, $data);
+        return $this->predictionService->createModelPrediction($owner, $name, $version, $data, $headers);
+    }
+
+    public function search(string $query, ?int $limit = null)
+    {
+        return $this->searchService->search($query, $limit);
     }
 }

--- a/src/Services/CollectionService.php
+++ b/src/Services/CollectionService.php
@@ -17,8 +17,8 @@ class CollectionService
     /*
      * https://replicate.com/docs/reference/http#collections.list
      */
-    public function list()
+    public function list(array $query = [])
     {
-        return Http::replicate()->get('/collections');
+        return Http::replicate()->get('/collections', $query);
     }
 }

--- a/src/Services/DeploymentService.php
+++ b/src/Services/DeploymentService.php
@@ -9,9 +9,9 @@ class DeploymentService
     /*
     * https://replicate.com/docs/reference/http#deployments.list
     */
-    public function list()
+    public function list(array $query = [])
     {
-        return Http::replicate()->get('/deployments');
+        return Http::replicate()->get('/deployments', $query);
     }
 
     /*
@@ -36,5 +36,13 @@ class DeploymentService
     public function update(string $owner, string $name, array $data)
     {
         return Http::replicate()->patch("/deployments/$owner/$name", $data);
+    }
+
+    /*
+     * https://replicate.com/docs/reference/http#deployments.delete
+     */
+    public function delete(string $owner, string $name)
+    {
+        return Http::replicate()->delete("/deployments/$owner/$name");
     }
 }

--- a/src/Services/ModelService.php
+++ b/src/Services/ModelService.php
@@ -57,8 +57,44 @@ class ModelService
     /*
      * https://replicate.com/docs/reference/http#models.list
      */
-    public function list()
+    public function list(array $query = [])
     {
-        return Http::replicate()->get('/models');
+        return Http::replicate()->get('/models', $query);
+    }
+
+    /*
+     * https://replicate.com/docs/reference/http#models.update
+     */
+    public function update(string $owner, string $name, array $data)
+    {
+        return Http::replicate()->patch("/models/$owner/$name", $data);
+    }
+
+    /*
+     * https://replicate.com/docs/reference/http#models.search
+     * Uses the non-standard QUERY HTTP method with a raw text/plain body.
+     */
+    public function search(string $query)
+    {
+        return Http::replicate()
+            ->withBody($query, 'text/plain')
+            ->send('QUERY', '/models');
+    }
+
+    /*
+     * https://replicate.com/docs/reference/http#models.examples.list
+     */
+    public function listExamples(string $owner, string $name, array $query = [])
+    {
+        return Http::replicate()->get("/models/$owner/$name/examples", $query);
+    }
+
+    /*
+     * https://replicate.com/docs/reference/http#models.readme.get
+     * Returns the README as plain-text Markdown (not JSON).
+     */
+    public function readme(string $owner, string $name)
+    {
+        return Http::replicate()->get("/models/$owner/$name/readme");
     }
 }

--- a/src/Services/PredictionService.php
+++ b/src/Services/PredictionService.php
@@ -8,10 +8,11 @@ class PredictionService
 {
     /*
     * https://replicate.com/docs/reference/http#predictions.create
+    * Pass headers like ['Prefer' => 'wait=60', 'Cancel-After' => '5m'].
     */
-    public function create(array $data)
+    public function create(array $data, array $headers = [])
     {
-        return Http::replicate()->post('/predictions', $data);
+        return Http::replicate()->withHeaders($headers)->post('/predictions', $data);
     }
 
     /*
@@ -25,9 +26,9 @@ class PredictionService
     /*
      * https://replicate.com/docs/reference/http#predictions.list
      */
-    public function list()
+    public function list(array $query = [])
     {
-        return Http::replicate()->get('/predictions');
+        return Http::replicate()->get('/predictions', $query);
     }
 
     /*
@@ -40,17 +41,19 @@ class PredictionService
 
     /*
      * https://replicate.com/docs/reference/http#deployments.predictions.create
+     * Pass headers like ['Prefer' => 'wait=60', 'Cancel-After' => '5m'].
      */
-    public function createDeploymentPrediction(string $owner, string $name, array $data)
+    public function createDeploymentPrediction(string $owner, string $name, array $data, array $headers = [])
     {
-        return Http::replicate()->post("/deployments/$owner/$name/predictions", $data);
+        return Http::replicate()->withHeaders($headers)->post("/deployments/$owner/$name/predictions", $data);
     }
 
     /*
      * https://replicate.com/docs/reference/http#models.predictions.create
+     * Pass headers like ['Prefer' => 'wait=60', 'Cancel-After' => '5m'].
      */
-    public function createModelPrediction(string $owner, string $name, string $version, array $data)
+    public function createModelPrediction(string $owner, string $name, string $version, array $data, array $headers = [])
     {
-        return Http::replicate()->post("/models/$owner/$name/predictions", $data);
+        return Http::replicate()->withHeaders($headers)->post("/models/$owner/$name/predictions", $data);
     }
 }

--- a/src/Services/SearchService.php
+++ b/src/Services/SearchService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace HalilCosdu\Replicate\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class SearchService
+{
+    /*
+     * https://replicate.com/docs/reference/http#search
+     * Beta: search public models, collections, and docs.
+     */
+    public function search(string $query, ?int $limit = null)
+    {
+        $parameters = array_filter(['query' => $query, 'limit' => $limit]);
+
+        return Http::replicate()->get('/search', $parameters);
+    }
+}

--- a/src/Services/TrainingService.php
+++ b/src/Services/TrainingService.php
@@ -25,9 +25,9 @@ class TrainingService
     /*
      * https://replicate.com/docs/reference/http#trainings.list
      */
-    public function list()
+    public function list(array $query = [])
     {
-        return Http::replicate()->get('/trainings');
+        return Http::replicate()->get('/trainings', $query);
     }
 
     /*

--- a/tests/V13EndpointsTest.php
+++ b/tests/V13EndpointsTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use HalilCosdu\Replicate\Facades\Replicate;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::fake();
+});
+
+describe('search', function () {
+    it('GETs /search with the query', function () {
+        Replicate::search('nano banana');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && str_contains($request->url(), '/search')
+            && str_contains($request->url(), 'query=nano'));
+    });
+
+    it('forwards the limit parameter when provided', function () {
+        Replicate::search('nano banana', 5);
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && str_contains($request->url(), 'limit=5')
+            && str_contains($request->url(), 'query=nano'));
+    });
+});
+
+describe('models.update', function () {
+    it('PATCHes model metadata', function () {
+        Replicate::updateModel('alice', 'detector', ['description' => 'updated']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'PATCH'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector'
+            && $request['description'] === 'updated');
+    });
+});
+
+describe('models.search', function () {
+    it('sends a QUERY request with a text/plain body', function () {
+        Replicate::searchModels('hello');
+
+        Http::assertSent(fn ($request) => $request->method() === 'QUERY'
+            && $request->url() === 'https://api.replicate.com/v1/models'
+            && $request->body() === 'hello'
+            && $request->hasHeader('Content-Type', 'text/plain'));
+    });
+});
+
+describe('models.examples.list', function () {
+    it('lists model examples', function () {
+        Replicate::listModelExamples('alice', 'detector');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/examples');
+    });
+
+    it('forwards query parameters', function () {
+        Replicate::listModelExamples('alice', 'detector', ['cursor' => 'abc']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && str_contains($request->url(), 'cursor=abc'));
+    });
+});
+
+describe('models.readme.get', function () {
+    it('gets the model readme', function () {
+        Replicate::getModelReadme('alice', 'detector');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://api.replicate.com/v1/models/alice/detector/readme');
+    });
+});
+
+describe('deployments.delete', function () {
+    it('deletes a deployment', function () {
+        Replicate::deleteDeployment('alice', 'my-deployment');
+
+        Http::assertSent(fn ($request) => $request->method() === 'DELETE'
+            && $request->url() === 'https://api.replicate.com/v1/deployments/alice/my-deployment');
+    });
+});
+
+describe('prediction headers', function () {
+    it('forwards Prefer and Cancel-After headers on createPrediction', function () {
+        Replicate::createPrediction(
+            ['version' => 'abc', 'input' => ['text' => 'hi']],
+            ['Prefer' => 'wait=60', 'Cancel-After' => '5m']
+        );
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/predictions'
+            && $request->hasHeader('Prefer', 'wait=60')
+            && $request->hasHeader('Cancel-After', '5m'));
+    });
+
+    it('forwards headers on createModelPrediction', function () {
+        Replicate::createModelPrediction('meta', 'llama-3', 'v1', ['input' => []], ['Prefer' => 'wait=10']);
+
+        Http::assertSent(fn ($request) => $request->hasHeader('Prefer', 'wait=10'));
+    });
+
+    it('forwards headers on createDeploymentPrediction', function () {
+        Replicate::createDeploymentPrediction('alice', 'dep', ['input' => []], ['Cancel-After' => '30s']);
+
+        Http::assertSent(fn ($request) => $request->hasHeader('Cancel-After', '30s'));
+    });
+
+    it('omits extra headers when none are passed (backwards compatible)', function () {
+        Replicate::createPrediction(['version' => 'abc']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://api.replicate.com/v1/predictions');
+    });
+});
+
+describe('list query parameters', function () {
+    it('forwards filters on listPredictions', function () {
+        Replicate::listPredictions(['created_after' => '2024-01-01T00:00:00Z']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && str_contains($request->url(), 'created_after=2024-01-01'));
+    });
+
+    it('forwards sort on listModels', function () {
+        Replicate::listModels(['sort_by' => 'model_created_at', 'sort_direction' => 'desc']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && str_contains($request->url(), 'sort_by=model_created_at')
+            && str_contains($request->url(), 'sort_direction=desc'));
+    });
+
+    it('forwards cursor on listTrainings', function () {
+        Replicate::listTrainings(['cursor' => 'page2']);
+
+        Http::assertSent(fn ($request) => str_contains($request->url(), 'cursor=page2'));
+    });
+
+    it('sends a bare request when no query is passed (backwards compatible)', function () {
+        Replicate::listModels();
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://api.replicate.com/v1/models');
+    });
+});


### PR DESCRIPTION
Second release. Closes the gap between this client and the current [Replicate HTTP API](https://replicate.com/docs/reference/http). All changes are additive / backwards-compatible.

## Added — 6 previously-missing endpoints
- `search($query, $limit = null)` — new `SearchService` (beta `GET /search`).
- `updateModel($owner, $name, $data)` — `PATCH /models/{owner}/{name}`.
- `searchModels($query)` — `QUERY /models` (non-standard HTTP method, raw `text/plain` body, implemented via `Http::send('QUERY', ...)`).
- `listModelExamples($owner, $name, $query = [])` — `GET /models/{owner}/{name}/examples`.
- `getModelReadme($owner, $name)` — `GET /models/{owner}/{name}/readme` (returns plain-text Markdown, not JSON).
- `deleteDeployment($owner, $name)` — `DELETE /deployments/{owner}/{name}`.

## Added — request controls (backwards compatible)
- **Prediction headers** — `createPrediction`, `createModelPrediction`, `createDeploymentPrediction` now accept an optional `array $headers = []` for `Prefer: wait=n` (sync mode) and `Cancel-After: 5m`.
- **List filters / pagination** — every list method now accepts an optional `array $query = []` forwarded as query parameters (`cursor`, `created_after`, `source`, `sort_by`, `sort_direction`).

## Tests
- +16 `Http::fake` tests covering every new method, header forwarding, query forwarding, and the `QUERY`+`text/plain` shape. 32 → 48 tests.

## Verification (local)
- [x] `composer test` — 48 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `composer format` — clean

> CI will likely show as failing due to the account-level Actions billing lock; the code side is green locally.

## Out of scope (future)
- Fluent request builder, typed pagination DTOs, auto-pagination, response DTOs, live integration tests.